### PR TITLE
setShuntVoltageLimit() has been modified

### DIFF
--- a/INA226.cpp
+++ b/INA226.cpp
@@ -231,7 +231,7 @@ void INA226::setBusVoltageLimit(float voltage)
 
 void INA226::setShuntVoltageLimit(float voltage)
 {
-    uint16_t value = voltage * 25000;
+    uint16_t value = voltage / 0.0000025;
     writeRegister16(INA226_REG_ALERTLIMIT, value);
 }
 


### PR DESCRIPTION
Hi,

I just changed uint16_t value = voltage  \* 25000; to this uint16_t value = voltage / 0.0000025;
Because it was setting alert incorrectly for shuntOverlimit()
After this change it works fine.

And thank you for your time and effort for making this library.

Regards
Neutron
